### PR TITLE
Default sort by newest

### DIFF
--- a/src/TableOfContents.tsx
+++ b/src/TableOfContents.tsx
@@ -30,7 +30,7 @@ function parseDateFromName(name: string): Date | null {
 
 export default function TableOfContents() {
   const [query, setQuery] = useState('')
-  const [sortOption, setSortOption] = useState<'title-asc' | 'title-desc' | 'date-new' | 'date-old'>('title-asc')
+  const [sortOption, setSortOption] = useState<'title-asc' | 'title-desc' | 'date-new' | 'date-old'>('date-new')
   // derive page names from file paths for TSX files
   const tsxEntries = Object.keys(modules).map((path) => {
     const name = path.match(/\.\/pages\/(.*)\.(?:tsx|jsx)$/)?.[1] || 'unknown'


### PR DESCRIPTION
## Summary
- default to sorting pages by newest first

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6847c2cfea9c832fb49f98a07afff4db