### PR TITLE
Fix blank page on GitHub Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "node scripts/auto-install-deps.cjs && node scripts/copy-html.cjs && vite build",
+    "build": "node scripts/auto-install-deps.cjs && node scripts/copy-html.cjs && vite build && node scripts/copy-404.cjs",
     "lint": "eslint .",
     "preview": "vite preview",
     "check-deps": "node scripts/check-dependencies.cjs",
@@ -17,7 +17,8 @@
     "deps:check": "node scripts/check-dependencies.cjs --suggest",
     "deps:install": "node scripts/auto-install-deps.cjs",
     "page:new": "node scripts/generate-page.cjs",
-    "copy-html": "node scripts/copy-html.cjs"
+    "copy-html": "node scripts/copy-html.cjs",
+    "copy-404": "node scripts/copy-404.cjs"
   },
   "dependencies": {
     "date-fns": "^3.6.0",

--- a/scripts/copy-404.cjs
+++ b/scripts/copy-404.cjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const distDir = path.join(__dirname, '..', 'dist');
+const indexPath = path.join(distDir, 'index.html');
+const targetPath = path.join(distDir, '404.html');
+
+if (fs.existsSync(indexPath)) {
+  fs.copyFileSync(indexPath, targetPath);
+  console.log('✅ Copied index.html to 404.html');
+} else {
+  console.error('❌ index.html not found in dist. Run build first.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- copy index.html to `404.html` after build
- add `copy-404` script and integrate with `npm run build`

## Testing
- `npm run build`
- `npm run lint` *(fails: Unexpected any in 250620- speaker amp matching.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68586ff5e16c832fa9a8185d2b4ff89d